### PR TITLE
Feat/5 handle request errors

### DIFF
--- a/src/translate/translate.controller.ts
+++ b/src/translate/translate.controller.ts
@@ -10,21 +10,21 @@ interface Response {
 export class TranslateController {
   constructor(private translateService: TranslateService) {}
 
-  @Post('/papago')
+  @Post('papago')
   translateWithPapago(
     @Body() translateQueryDto: TranslateQueryDto,
   ): Promise<Response> {
     return this.translateService.translateWithPapago(translateQueryDto)
   }
 
-  @Post('/kakao')
+  @Post('kakao')
   translateWithKakao(
     @Body() translateQueryDto: TranslateQueryDto,
   ): Promise<Response> {
     return this.translateService.translateWithKakao(translateQueryDto)
   }
 
-  @Post('/google')
+  @Post('google')
   translateWithGoogle(
     @Body() translateQueryDto: TranslateQueryDto,
   ): Promise<Response> {

--- a/src/translate/translate.service.ts
+++ b/src/translate/translate.service.ts
@@ -1,4 +1,4 @@
-import { HttpService, Injectable } from '@nestjs/common'
+import { HttpException, HttpService, Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { TranslationServiceClient } from '@google-cloud/translate'
 import { TranslateQueryDto } from './dto/translate-query.dto'
@@ -8,7 +8,10 @@ export class TranslateService {
   constructor(
     private httpService: HttpService,
     private configService: ConfigService,
-  ) {}
+    private logger: Logger,
+  ) {
+    logger = new Logger('Translate Error')
+  }
 
   async translateWithPapago(translateQueryDto: TranslateQueryDto) {
     const { query, source, target } = translateQueryDto
@@ -36,7 +39,8 @@ export class TranslateService {
       const result = response.data.message.result.translatedText
       return { result }
     } catch (error) {
-      console.log(error.message)
+      this.logger.error('Papago daily quota exceeded')
+      throw new HttpException('Papago daily quota exceeded', 520)
     }
   }
 
@@ -78,7 +82,8 @@ export class TranslateService {
       }
       return { result }
     } catch (error) {
-      console.log(error.message)
+      this.logger.error('Kakao daily quota exceeded')
+      throw new HttpException('Kakao daily quota exceeded', 520)
     }
   }
 
@@ -95,7 +100,8 @@ export class TranslateService {
       const result = response.translations[0].translatedText
       return { result }
     } catch (error) {
-      console.error(error)
+      this.logger.error('Google daily quota exceeded')
+      throw new HttpException('Google daily quota exceeded', 520)
     }
   }
 

--- a/src/translate/translate.service.ts
+++ b/src/translate/translate.service.ts
@@ -5,13 +5,12 @@ import { TranslateQueryDto } from './dto/translate-query.dto'
 
 @Injectable()
 export class TranslateService {
+  private logger = new Logger('Translate Error')
+
   constructor(
     private httpService: HttpService,
     private configService: ConfigService,
-    private logger: Logger,
-  ) {
-    logger = new Logger('Translate Error')
-  }
+  ) {}
 
   async translateWithPapago(translateQueryDto: TranslateQueryDto) {
     const { query, source, target } = translateQueryDto
@@ -39,8 +38,12 @@ export class TranslateService {
       const result = response.data.message.result.translatedText
       return { result }
     } catch (error) {
-      this.logger.error('Papago daily quota exceeded')
-      throw new HttpException('Papago daily quota exceeded', 520)
+      if (error.response.status === 429) {
+        this.logger.error('Papago daily quota exceeded')
+        throw new HttpException('Papago daily quota exceeded', 429)
+      }
+      this.logger.error(error.message)
+      throw new HttpException(error.message, error.response.status)
     }
   }
 
@@ -82,8 +85,12 @@ export class TranslateService {
       }
       return { result }
     } catch (error) {
-      this.logger.error('Kakao daily quota exceeded')
-      throw new HttpException('Kakao daily quota exceeded', 520)
+      if (error.response.status === 429) {
+        this.logger.error('Kakao daily quota exceeded')
+        throw new HttpException('Kakao daily quota exceeded', 429)
+      }
+      this.logger.error(error.message)
+      throw new HttpException(error.message, error.response.status)
     }
   }
 
@@ -100,8 +107,11 @@ export class TranslateService {
       const result = response.translations[0].translatedText
       return { result }
     } catch (error) {
-      this.logger.error('Google daily quota exceeded')
-      throw new HttpException('Google daily quota exceeded', 520)
+      if (error.reponse.status === 429) {
+        this.logger.error('Google daily quota exceeded')
+        throw new HttpException('Google daily quota exceeded', 429)
+      }
+      throw new HttpException(error.message, error.response.status)
     }
   }
 


### PR DESCRIPTION
1. 번역 API 에서 상태 코드 429 에러 발생 시 아래 코드로 처리

```typescript
if (error.response.status === 429) {
    this.logger.error('Papago daily quota exceeded')
    throw new HttpException('Papago daily quota exceeded', 429)
}
```

2. 기타 에러 발생시 아래 코드로 처리

```typescript
this.logger.error(error.message)
throw new HttpException(error.message, error.response.status)
```

Closes #5 